### PR TITLE
Hide classroom content from visitors on welcome page

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,10 +2,28 @@
 
 class WelcomeController < ApplicationController
   def index
-    if params[:tag]
-      @tutorials = Tutorial.tagged_with(params[:tag]).paginate(page: params[:page], per_page: 5)
+    if current_user
+      @tutorials = all_tutorials
     else
-      @tutorials = Tutorial.all.paginate(page: params[:page], per_page: 5)
+      @tutorials = visitor_tutorials
+    end
+  end
+
+  private
+
+  def all_tutorials
+    if params[:tag]
+      Tutorial.tagged_with(params[:tag]).paginate(page: params[:page], per_page: 5)
+    else
+      Tutorial.all.paginate(page: params[:page], per_page: 5)
+    end
+  end
+
+  def visitor_tutorials
+    if params[:tag]
+      Tutorial.where(classroom: false).tagged_with(params[:tag]).paginate(page: params[:page], per_page: 5)
+    else
+      Tutorial.where(classroom: false).paginate(page: params[:page], per_page: 5)
     end
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,28 +2,11 @@
 
 class WelcomeController < ApplicationController
   def index
+    welcome = WelcomeFacade.new
     if current_user
-      @tutorials = all_tutorials
+      @tutorials = welcome.all_tutorials(params[:page], params[:tag])
     else
-      @tutorials = visitor_tutorials
-    end
-  end
-
-  private
-
-  def all_tutorials
-    if params[:tag]
-      Tutorial.tagged_with(params[:tag]).paginate(page: params[:page], per_page: 5)
-    else
-      Tutorial.all.paginate(page: params[:page], per_page: 5)
-    end
-  end
-
-  def visitor_tutorials
-    if params[:tag]
-      Tutorial.where(classroom: false).tagged_with(params[:tag]).paginate(page: params[:page], per_page: 5)
-    else
-      Tutorial.where(classroom: false).paginate(page: params[:page], per_page: 5)
+      @tutorials = welcome.visitor_tutorials(params[:page], params[:tag])
     end
   end
 end

--- a/app/facades/welcome_facade.rb
+++ b/app/facades/welcome_facade.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class WelcomeFacade
+
+  def all_tutorials(page, tag)
+    if tag
+      Tutorial.tagged_with(tag).paginate(page: page, per_page: 5)
+    else
+      Tutorial.all.paginate(page: page, per_page: 5)
+    end
+  end
+
+  def visitor_tutorials(page, tag)
+    if tag
+      Tutorial.where(classroom: false).tagged_with(tag).paginate(page: page, per_page: 5)
+    else
+      Tutorial.where(classroom: false).paginate(page: page, per_page: 5)
+    end
+  end
+
+end

--- a/spec/features/user/user_can_see_classroom_tutorials_spec.rb
+++ b/spec/features/user/user_can_see_classroom_tutorials_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'As a User' do
+  it 'the root page does display classroom content tutorials' do
+    user = create(:user)
+
+    tutorial_1 = create(:tutorial)
+    tutorial_2 = create(:tutorial, classroom: true)
+
+    video_1 = create(:video, tutorial_id: tutorial_1.id)
+    video_2 = create(:video, tutorial_id: tutorial_1.id)
+    video_3 = create(:video, tutorial_id: tutorial_2.id)
+    video_4 = create(:video, tutorial_id: tutorial_2.id)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit root_path
+
+    expect(page).to have_css('.tutorial', count: 2)
+
+    within('.tutorials') do
+      expect(page).to have_css('.tutorial')
+      expect(page).to have_css('.tutorial-description')
+      expect(page).to have_content(tutorial_1.title)
+      expect(page).to have_content(tutorial_1.description)
+      expect(page).to have_css('.tutorial')
+      expect(page).to have_css('.tutorial-description')
+      expect(page).to have_content(tutorial_2.title)
+      expect(page).to have_content(tutorial_2.description)
+    end
+  end
+end

--- a/spec/features/vistors/visitor_cannot_see_classroom_tutorials_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_tutorials_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'As a Visitor' do
+  it 'the root page does not display classroom content tutorials' do
+    tutorial_1 = create(:tutorial)
+    tutorial_2 = create(:tutorial, classroom: true)
+
+    video_1 = create(:video, tutorial_id: tutorial_1.id)
+    video_2 = create(:video, tutorial_id: tutorial_1.id)
+    video_3 = create(:video, tutorial_id: tutorial_2.id)
+    video_4 = create(:video, tutorial_id: tutorial_2.id)
+
+    visit root_path
+
+    expect(page).to have_css('.tutorial', count: 1)
+
+    within(first('.tutorials')) do
+      expect(page).to have_css('.tutorial')
+      expect(page).to have_css('.tutorial-description')
+      expect(page).to have_content(tutorial_1.title)
+      expect(page).to have_content(tutorial_1.description)
+    end
+  end
+end


### PR DESCRIPTION
Concerns: Let me know your thoughts on possibly moving the 2 private helper methods I made in the welcome controller into a welcome facade.

Functionality: I made a 2 tests (one user and one visitor) with 2 tutorials each (one tutorial is classroom content and the other is not). The visitor test verifies that only the non-classroom content tutorial is shown on the welcome page, while the user test verifies that both tutorials are displayed.