### PR TITLE
OAuth Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem 'figaro'
 gem 'google-api-client'
 gem 'jquery'
 gem 'omniauth-census', git: 'https://github.com/turingschool-projects/omniauth-census'
+gem 'omniauth-github'
 gem 'omniauth-google-oauth2'
 gem 'will_paginate'
 gem 'yt', '~> 0.29.1'
-gem 'omniauth-github'
 
 group :development, :test do
   gem 'awesome_print'

--- a/app/controllers/github_controller.rb
+++ b/app/controllers/github_controller.rb
@@ -1,9 +1,9 @@
-class GithubController < ApplicationController
+# frozen_string_literal: true
 
+class GithubController < ApplicationController
   def create
-    token = request.env["omniauth.auth"]["credentials"]["token"]
+    token = request.env['omniauth.auth']['credentials']['token']
     current_user.update(github_token: token)
     redirect_to '/dashboard'
   end
-
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,10 +3,10 @@
 class WelcomeController < ApplicationController
   def index
     welcome = WelcomeFacade.new
-    if current_user
-      @tutorials = welcome.all_tutorials(params[:page], params[:tag])
-    else
-      @tutorials = welcome.visitor_tutorials(params[:page], params[:tag])
-    end
+    @tutorials = if current_user
+                   welcome.all_tutorials(params[:page], params[:tag])
+                 else
+                   welcome.visitor_tutorials(params[:page], params[:tag])
+                 end
   end
 end

--- a/app/facades/welcome_facade.rb
+++ b/app/facades/welcome_facade.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class WelcomeFacade
-
   def all_tutorials(page, tag)
     if tag
       Tutorial.tagged_with(tag).paginate(page: page, per_page: 5)
@@ -17,5 +16,4 @@ class WelcomeFacade
       Tutorial.where(classroom: false).paginate(page: page, per_page: 5)
     end
   end
-
 end

--- a/spec/features/users/user_authenticates_github_spec.rb
+++ b/spec/features/users/user_authenticates_github_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+# As a user
+# When I visit /dashboard
+# Then I should see a link that is styled like a button that says "Connect to Github"
+# And when I click on "Connect to Github"
+# Then I should go through the OAuth process
+# And I should be redirected to /dashboard
+# And I should see all of the content from the previous Github stories (repos, followers, and following)
+
+describe "A logged in user: " do
+  it "can connect to Github" do
+    visit '/'
+    create(:user)
+    binding.pry
+  end
+end

--- a/spec/features/users/user_authenticates_github_spec.rb
+++ b/spec/features/users/user_authenticates_github_spec.rb
@@ -9,15 +9,32 @@ require 'rails_helper'
 # And I should see all of the content from the previous Github stories (repos, followers, and following)
 
 describe "A logged in user: " do
-  it "can connect to Github" do
-    # tutorial = create(:tutorial, title: 'How to Tie Your Shoes')
-    # video = create(:video, title: 'The Bunny Ears Technique', tutorial: tutorial)
+  it "can connect to Github via OAuth" do
     user = create(:user)
+
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit dashboard_path
-    expect(page).to have_link('Connect to GitHub')
-    # save_and_open_page
-    # binding.pry
+
+    stub_omniauth
+    click_on 'Connect to GitHub'
+    user.reload
+
+    expect(user.github_token).to eq('pizza')
+  end
+
+  def stub_omniauth
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+      provider: 'github',
+      extra: {
+        raw_info: {
+          login: "1234"
+        }
+      },
+      credentials: {
+        token: "pizza",
+      }
+    })
   end
 end

--- a/spec/features/users/user_authenticates_github_spec.rb
+++ b/spec/features/users/user_authenticates_github_spec.rb
@@ -10,8 +10,14 @@ require 'rails_helper'
 
 describe "A logged in user: " do
   it "can connect to Github" do
-    visit '/'
-    create(:user)
-    binding.pry
+    # tutorial = create(:tutorial, title: 'How to Tie Your Shoes')
+    # video = create(:video, title: 'The Bunny Ears Technique', tutorial: tutorial)
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+    expect(page).to have_link('Connect to GitHub')
+    # save_and_open_page
+    # binding.pry
   end
 end


### PR DESCRIPTION
- Merged with master after successfully spiking

Testing for the following:
 When a logged in user visits '/dashboard':
- they see a link that is styled like a button that says "Connect to Github"
- when they click on "Connect to Github", they successfully go through the OAuth process

More robust testing will be added as more features are added.  
- We will need to use Webmock and VCR for future tests involving API keys.  
- Stubbing OAuth works for the scope of this feature.

All tests passing except for the three known failures.