### PR TITLE
Add Test for: User Dashboard: Github Following

### DIFF
--- a/spec/features/users/user_can_get_data_from_github_spec.rb
+++ b/spec/features/users/user_can_get_data_from_github_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "A user connected to github" do
-  it "will have github repos and followers on the dashboard" do
+  it "will have github repos, followers and following on the dashboard" do
     user = create(:user, github_token: ENV['example_github_token'])
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -13,6 +13,9 @@ describe "A user connected to github" do
     stub_request(:get, "https://api.github.com/user/followers?access_token=#{ENV['example_github_token']}")
       .to_return(status: 200, body: json_followers)
 
+    json_following = File.open('./fixtures/following_data.json')
+    stub_request(:get, "https://api.github.com/user/following?access_token=#{ENV['example_github_token']}")
+      .to_return(status: 200, body: json_following)
     visit dashboard_path
 
     expect(page).to have_content("My GitHub")
@@ -21,5 +24,8 @@ describe "A user connected to github" do
 
     expect(page).to have_content("Followers")
     expect(page).to have_link("leiyakenney")
+
+    expect(page).to have_content("Following")
+    expect(page).to have_link("hillstew")
   end
 end


### PR DESCRIPTION
Adds lines of code:
- to spec/features/users/user_can_get_data_from_github_spec.rb
- tests that a user who is connected to their Github account can see other Github users they are following.  They can click on the user's name and will be taken to their Github profile.