### PR TITLE
Admin: New Tutorial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,8 +46,8 @@ group :development, :test do
 end
 
 group :test do
-  gem 'webmock'
   gem 'vcr'
+  gem 'webmock'
 end
 
 group :development do

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 class Admin::TutorialsController < Admin::BaseController
-  def create; end
-
   def new
     @tutorial = Tutorial.new
   end
+
+  def create
+    new_tutorial = Tutorial.new(new_tutorial_params)
+    new_tutorial.save
+    if new_tutorial.save
+      flash[:success] = 'Successfully added tutorial.'
+      redirect_to tutorial_path(new_tutorial.id)
+    else
+      flash[:error] = 'Tutorial was not added.'
+      redirect_to new_admin_tutorial_path
+    end
+  end
+
 
   def edit
     @tutorial = Tutorial.find(params[:id])
@@ -20,6 +31,9 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   private
+  def new_tutorial_params
+    params.require(:tutorial).permit(:id,:title, :description, :thumbnail)
+  end
 
   def tutorial_params
     params.require(:tutorial).permit(:tag_list)

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -17,7 +17,6 @@ class Admin::TutorialsController < Admin::BaseController
     end
   end
 
-
   def edit
     @tutorial = Tutorial.find(params[:id])
   end

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -32,7 +32,7 @@ class Admin::TutorialsController < Admin::BaseController
 
   private
   def new_tutorial_params
-    params.require(:tutorial).permit(:id,:title, :description, :thumbnail)
+    params.require(:tutorial).permit(:id,:title, :description, :thumbnail, :playlist_id)
   end
 
   def tutorial_params

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -30,8 +30,9 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   private
+
   def new_tutorial_params
-    params.require(:tutorial).permit(:id,:title, :description, :thumbnail, :playlist_id)
+    params.require(:tutorial).permit(:id, :title, :description, :thumbnail, :playlist_id)
   end
 
   def tutorial_params

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Admin::TutorialsController < Admin::BaseController
-  def edit
-    @tutorial = Tutorial.find(params[:id])
-  end
-
   def create; end
 
   def new
     @tutorial = Tutorial.new
+  end
+
+  def edit
+    @tutorial = Tutorial.find(params[:id])
   end
 
   def update

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserFacade
-
   def initialize(user)
     @github_service = GithubService.new(user)
   end
@@ -9,21 +8,21 @@ class UserFacade
   def format_repos(num)
     full_repos_array = @github_service.get_repos
     full_repos_array[0..(num - 1)].map do |repo_hash|
-      Repository.new(repo_hash["name"], repo_hash["html_url"])
+      Repository.new(repo_hash['name'], repo_hash['html_url'])
     end
   end
 
   def format_followers
     full_followers_array = @github_service.get_followers
     full_followers_array.map do |follower_hash|
-      GithubUser.new(follower_hash["login"], follower_hash["html_url"])
+      GithubUser.new(follower_hash['login'], follower_hash['html_url'])
     end
   end
 
   def format_following
     full_following_array = @github_service.get_following
     full_following_array.map do |following_hash|
-      GithubUser.new(following_hash["login"], following_hash["html_url"])
+      GithubUser.new(following_hash['login'], following_hash['html_url'])
     end
   end
 end

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -7,5 +7,4 @@ class GithubUser
     @handle = handle
     @url = url
   end
-
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -2,10 +2,9 @@
 
 class Repository
   attr_reader :name, :url
-  
+
   def initialize(name, url)
     @name = name
     @url = url
   end
-
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -8,5 +8,5 @@ class Tutorial < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :description
   validates_presence_of :thumbnail
-  validates_presence_of :playlist_id
+  # validates_presence_of :playlist_id
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -8,5 +8,4 @@ class Tutorial < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :description
   validates_presence_of :thumbnail
-  validates_presence_of :playlist_id
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -8,5 +8,5 @@ class Tutorial < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :description
   validates_presence_of :thumbnail
-  # validates_presence_of :playlist_id
+  validates_presence_of :playlist_id
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class GithubService
-
   def initialize(user)
     @user = user
   end
@@ -25,7 +24,6 @@ class GithubService
 
   def conn
     token = @user.github_token
-    Faraday.new(url: "https://api.github.com/user", params: {access_token: token})
+    Faraday.new(url: 'https://api.github.com/user', params: { access_token: token })
   end
-
 end

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -6,15 +6,5 @@
   <%= f.text_area :description, class: "block col-4 field"  %>
   <%= f.label :thumbnail %>
   <%= f.text_field :thumbnail, class: "block col-4 field"  %>
-  <%= f.label :playlist_id %>
-  <%= f.text_field :playlist_id, class: "block col-4 field"  %>
-
-  <h3>Videos</h3>
-
-  <%= f.fields_for :videos do |builder| %>
-    <%= f.label :youtube_url %>
-    <%= f.text_field :video_id, class: "block col-4 field" %>
-  <% end %>
-
   <%= f.submit "Save", class: "mt2 btn btn-primary mb1 bg-teal"  %>
 <% end %>

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -6,6 +6,8 @@
   <%= f.text_area :description, class: "block col-4 field"  %>
   <%= f.label :thumbnail %>
   <%= f.text_field :thumbnail, class: "block col-4 field"  %>
+  <%= f.label :playlist_id %>
+  <%= f.text_field :playlist_id, class: "block col-4 field"  %>
 
   <h3>Videos</h3>
 

--- a/lib/tasks/video_position.rake
+++ b/lib/tasks/video_position.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 namespace :update_video do
-  desc "Change any nil video descriptions to 0"
+  desc 'Change any nil video descriptions to 0'
 
-  task :position => :environment do
+  task position: :environment do
     videos = Video.where(position: nil)
     videos.each do |video|
       video.update(position: 0)

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -12,13 +12,14 @@ describe "An admin visiting the admin dashboard" do
     fill_in 'tutorial[title]', with: 'Brownfield of Dreams'
     fill_in 'tutorial[description]', with: 'Tips to work in a brownfield project.'
     fill_in 'tutorial[thumbnail]', with: 'http://i3.ytimg.com/vi/BotaoeIFrYE/maxresdefault.jpg'
+    fill_in 'tutorial[playlist_id]', with: 'PL1Y67f0xPzdN6C-LPuTQ5yzlBoz2joWa5'
+
     click_on 'Save'
+    expect(page).to have_content('Successfully added tutorial.')
 
     new_tutorial_id = Tutorial.last.id
     expect(current_path).to eq(tutorial_path(new_tutorial_id))
-    # save_and_open_page
   end
+
+  # sad path testing
 end
-    # And I click on 'Save'
-    # Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
-    # And I should see a flash message that says "Successfully created tutorial."

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -21,4 +21,27 @@ describe "An admin visiting the admin dashboard" do
   end
 
   # sad path testing
+  it "displays a flash message if tutorial was not added" do
+    admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit '/admin/dashboard'
+
+    click_on 'New Tutorial'
+    expect(current_path).to eq(new_admin_tutorial_path)
+
+    fill_in 'tutorial[title]', with: 'Brownfield of Dreams'
+    fill_in 'tutorial[description]', with: 'Tips to work in a brownfield project.'
+
+    click_on 'Save'
+    expect(page).to have_content('Tutorial was not added.')
+    expect(current_path).to eq(new_admin_tutorial_path)
+
+    fill_in 'tutorial[title]', with: 'Brownfield of Dreams'
+    fill_in 'tutorial[description]', with: 'Tips to work in a brownfield project.'
+    fill_in 'tutorial[thumbnail]', with: 'http://i3.ytimg.com/vi/BotaoeIFrYE/maxresdefault.jpg'
+    click_on 'Save'
+
+    new_tutorial_id = Tutorial.last.id
+    expect(current_path).to eq(tutorial_path(new_tutorial_id))
+  end
 end

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -3,20 +3,19 @@ require 'rails_helper'
 describe "An admin visiting the admin dashboard" do
   it "allows admin to add new tutorial" do
     admin = create(:admin)
-    create_list(:tutorial, 2)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
     visit '/admin/dashboard'
-    expect(page).to have_css('.admin-tutorial-card', count: 2)
 
-    save_and_open_page
+    click_on 'New Tutorial'
+    expect(current_path).to eq(new_admin_tutorial_path)
 
+    # And I fill in 'title' with a meaningful name
+    # And I fill in 'description' with a some content
+    # And I fill in 'thumbnail' with a valid YouTube thumbnail
 
   end
 end
     # When I visit '/admin/tutorials/new'
-    # And I fill in 'title' with a meaningful name
-    # And I fill in 'description' with a some content
-    # And I fill in 'thumbnail' with a valid YouTube thumbnail
     # And I click on 'Save'
     # Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
     # And I should see a flash message that says "Successfully created tutorial."

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -12,7 +12,6 @@ describe "An admin visiting the admin dashboard" do
     fill_in 'tutorial[title]', with: 'Brownfield of Dreams'
     fill_in 'tutorial[description]', with: 'Tips to work in a brownfield project.'
     fill_in 'tutorial[thumbnail]', with: 'http://i3.ytimg.com/vi/BotaoeIFrYE/maxresdefault.jpg'
-    fill_in 'tutorial[playlist_id]', with: 'PL1Y67f0xPzdN6C-LPuTQ5yzlBoz2joWa5'
 
     click_on 'Save'
     expect(page).to have_content('Successfully added tutorial.')

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -9,13 +9,16 @@ describe "An admin visiting the admin dashboard" do
     click_on 'New Tutorial'
     expect(current_path).to eq(new_admin_tutorial_path)
 
-    # And I fill in 'title' with a meaningful name
-    # And I fill in 'description' with a some content
-    # And I fill in 'thumbnail' with a valid YouTube thumbnail
+    fill_in 'tutorial[title]', with: 'Brownfield of Dreams'
+    fill_in 'tutorial[description]', with: 'Tips to work in a brownfield project.'
+    fill_in 'tutorial[thumbnail]', with: 'http://i3.ytimg.com/vi/BotaoeIFrYE/maxresdefault.jpg'
+    click_on 'Save'
 
+    new_tutorial_id = Tutorial.last.id
+    expect(current_path).to eq(tutorial_path(new_tutorial_id))
+    # save_and_open_page
   end
 end
-    # When I visit '/admin/tutorials/new'
     # And I click on 'Save'
     # Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
     # And I should see a flash message that says "Successfully created tutorial."

--- a/spec/features/admin/admin_can_add_new_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_add_new_tutorial_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "An admin visiting the admin dashboard" do
+  it "allows admin to add new tutorial" do
+    admin = create(:admin)
+    create_list(:tutorial, 2)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit '/admin/dashboard'
+    expect(page).to have_css('.admin-tutorial-card', count: 2)
+
+    save_and_open_page
+
+
+  end
+end
+    # When I visit '/admin/tutorials/new'
+    # And I fill in 'title' with a meaningful name
+    # And I fill in 'description' with a some content
+    # And I fill in 'thumbnail' with a valid YouTube thumbnail
+    # And I click on 'Save'
+    # Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
+    # And I should see a flash message that says "Successfully created tutorial."

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -12,6 +12,5 @@ describe Tutorial, type: :model do
     it {should validate_presence_of(:title)}
     it {should validate_presence_of(:description)}
     it {should validate_presence_of(:thumbnail)}
-    it {should validate_presence_of(:playlist_id)}
   end
 end


### PR DESCRIPTION
Admin can add a new tutorial.

Adds the following:
- new test file spec/features/admin/admin_can_add_new_tutorial_spec.rb
- happy and sad path tests.
- code to create action and strong params in admin/tutorials_controller.rb
- routes already existed, no changes.

Removes the following:
- admin can add videos after successful creation of tutorial by visiting edit tutorial path for admins.
- validations for playlist_id.

All tests passing.  
Ran Rubocop, will need to reconfigure .yml file to resolve 8 offenses.