### PR TITLE
Admin can delete tutorial

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -29,6 +29,9 @@ class Admin::TutorialsController < Admin::BaseController
     redirect_to edit_admin_tutorial_path(tutorial)
   end
 
+  def destroy
+
+  end
   private
 
   def new_tutorial_params

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -30,7 +30,10 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def destroy
-
+    tutorial = Tutorial.find(params[:id])
+    tutorial.destroy
+    redirect_to admin_dashboard_path
+    # binding.pry
   end
   private
 

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -35,6 +35,7 @@ class Admin::TutorialsController < Admin::BaseController
     redirect_to admin_dashboard_path
     # binding.pry
   end
+
   private
 
   def new_tutorial_params

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }
+  has_many :videos, -> { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -15,7 +15,7 @@
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
         <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |
-        <%= link_to 'Destroy', tutorial_path(tutorial),
+        <%= link_to 'Destroy', admin_tutorial_path(tutorial),
                                method: :delete,
                                data: { confirm: 'Are you sure?' } %>
       </td>

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -1,24 +1,41 @@
 require 'rails_helper'
 
 describe 'An admin visiting the admin dashboard' do
-  before :each do
-    @admin = create(:admin)
-    @t1, @t2, @t3 = create_list(:tutorial, 3)
-    @t1v1 = create(:video, tutorial_id: @t1.id)
-    @t2v2 = create(:video, tutorial_id: @t2.id)
-
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
-    visit admin_dashboard_path
-  end
   it 'can delete a tutorial and associated videos' do
+    admin = create(:admin)
+    t1, t2, t3 = create_list(:tutorial, 3)
+    t1v1 = create(:video, tutorial_id: t1.id)
+    t2v1 = create(:video, tutorial_id: t2.id)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit admin_dashboard_path
     within(first('.admin-tutorial-card')) do
       click_on 'Destroy'
     end
 
     expect(current_path).to eq(admin_dashboard_path)
-    expect(page).to_not have_content(@t1.title)
-    expect(@t1.videos.count).to eq(0)
-    expect(page).to have_content(@t2.title)
-    expect(page).to have_content(@t3.title) 
+    expect(page).to_not have_content(t1.title)
+    expect(t1.videos.count).to eq(0)
+    expect(page).to have_content(t2.title)
+    expect(page).to have_content(t3.title)
+  end
+
+  it "can delete a tutorial that does not have any videos" do
+    admin = create(:admin)
+    t1, t2, t3 = create_list(:tutorial, 3)
+    t2v1 = create(:video, tutorial_id: t2.id)
+    t3v1 = create(:video, tutorial_id: t3.id)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit admin_dashboard_path
+
+    within(first('.admin-tutorial-card')) do
+      click_on 'Destroy'
+    end
+
+    expect(current_path).to eq(admin_dashboard_path)
+    expect(page).to_not have_content(t1.title)
+    expect(page).to have_content(t2.title)
+    expect(page).to have_content(t3.title)
   end
 end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'An admin visiting the admin dashboard' do
+  it 'can delete a tutorial and associated videos' do
+    admin = create(:admin)
+    t1, t2 = create_list(:tutorial, 2)
+    tv1 = create(:video, tutorial_id: t1)
+    tv2 = create(:video, tutorial_id: t2)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit '/admin/dashboard'
+
+  end
+end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -1,20 +1,24 @@
 require 'rails_helper'
 
 describe 'An admin visiting the admin dashboard' do
-  it 'can delete a tutorial and associated videos' do
-    admin = create(:admin)
-    t1, t2, t3 = create_list(:tutorial, 3)
-    t1v1 = create(:video, tutorial_id: t1.id)
-    t2v2 = create(:video, tutorial_id: t2.id)
+  before :each do
+    @admin = create(:admin)
+    @t1, @t2, @t3 = create_list(:tutorial, 3)
+    @t1v1 = create(:video, tutorial_id: @t1.id)
+    @t2v2 = create(:video, tutorial_id: @t2.id)
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
     visit admin_dashboard_path
-# save_and_open_page
+  end
+  it 'can delete a tutorial and associated videos' do
     within(first('.admin-tutorial-card')) do
       click_on 'Destroy'
     end
 
     expect(current_path).to eq(admin_dashboard_path)
-    expect(page).to_not have_content(t1.name)
+    expect(page).to_not have_content(@t1.title)
+    expect(@t1.videos.count).to eq(0)
+    expect(page).to have_content(@t2.title)
+    expect(page).to have_content(@t3.title) 
   end
 end

--- a/spec/features/admin/admin_can_delete_tutorial_spec.rb
+++ b/spec/features/admin/admin_can_delete_tutorial_spec.rb
@@ -3,12 +3,18 @@ require 'rails_helper'
 describe 'An admin visiting the admin dashboard' do
   it 'can delete a tutorial and associated videos' do
     admin = create(:admin)
-    t1, t2 = create_list(:tutorial, 2)
-    tv1 = create(:video, tutorial_id: t1)
-    tv2 = create(:video, tutorial_id: t2)
+    t1, t2, t3 = create_list(:tutorial, 3)
+    t1v1 = create(:video, tutorial_id: t1.id)
+    t2v2 = create(:video, tutorial_id: t2.id)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-    visit '/admin/dashboard'
+    visit admin_dashboard_path
+# save_and_open_page
+    within(first('.admin-tutorial-card')) do
+      click_on 'Destroy'
+    end
 
+    expect(current_path).to eq(admin_dashboard_path)
+    expect(page).to_not have_content(t1.name)
   end
 end


### PR DESCRIPTION
closes #5 
All tests passing.
Ran Rubocop, still have 8 offenses.
No new routes were added.

Adds the following:
- new test file spec/features/admin/admin_can_delete_tutorial_spec.rb to test that an admin can delete tutorial and its associated videos.
- dependent: :destroy to Tutorial model.
- changes route when admin clicks on Destroy to admin_tutorial_path(tutorial) from tutorial_path(tutorial)
- creates destroy action in admin/tutorials_controller.rb